### PR TITLE
Fix failing caddy install due out of date gpg key

### DIFF
--- a/provisioning/roles/sp_mini_4_setup_apps/tasks/main.yml
+++ b/provisioning/roles/sp_mini_4_setup_apps/tasks/main.yml
@@ -23,8 +23,8 @@
   become: yes
   shell: |
     apt install -y debian-keyring debian-archive-keyring apt-transport-https
-    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo tee /etc/apt/trusted.gpg.d/caddy-stable.asc
-    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
+    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | tee /etc/apt/sources.list.d/caddy-stable.list
     apt update
     apt-get install -y caddy=2.4.6
 


### PR DESCRIPTION
Fixes the following error.
```shell
$ apt update
# ...
Err:5 https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY ABA1F9B8875A6661
Reading package lists... Done
W: GPG error: https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY ABA1F9B8875A6661
E: The repository 'https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version InRelease' is not signed.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```